### PR TITLE
Disable bzip2 support for pbgzip

### DIFF
--- a/pbgzip/Makefile
+++ b/pbgzip/Makefile
@@ -1,7 +1,7 @@
 CC=			gcc
 CFLAGS=		-g -Wall -O2 -pthread
 #LDFLAGS=		-Wl,-rpath,\$$ORIGIN/../lib
-DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -DHAVE_LIBPTHREAD #-DDISABLE_BZ2
+DFLAGS=		-D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE -D_USE_KNETFILE -DHAVE_LIBPTHREAD -DDISABLE_BZ2
 AOBJS=		../bgzf.o ../knetfile.o util.o block.o consumer.o queue.o reader.o writer.o pbgzf.o pbgzip.o
 PROG=		pbgzip
 INCLUDES=	-I.
@@ -30,7 +30,7 @@ all:$(PROG)
 .PHONY:all-recur lib-recur clean-recur cleanlocal-recur install-recur
 
 pbgzip:lib-recur $(AOBJS)
-		$(CC) $(CFLAGS) -o $@ $(AOBJS) $(LDFLAGS) $(LIBPATH) -lm -lz -lbz2
+		$(CC) $(CFLAGS) -o $@ $(AOBJS) $(LDFLAGS) $(LIBPATH) -lm -lz
 
 #faidx_main.o:faidx.h razf.h
 


### PR DESCRIPTION
Nils;
pbgzip is super useful as a drop in replacement for bgzip. I'm seeing 10-12x improvements in some CPU-bound zipping of big fastq files.

This patch disables bz2 support in the Makefile, which seems to be broken at the moment and lets it build cleanly with standard blocked gzipped.

Would you be interested in forking pbgzip out as a separate repository to make it more available? This fills a nice missing need.
