### PR TITLE
Fix for small memory leak in the consumer code

### DIFF
--- a/pbgzip/consumer.c
+++ b/pbgzip/consumer.c
@@ -329,6 +329,7 @@ consumer_run(void *arg)
           }
           else if((NULL == c->reader && QUEUE_STATE_EOF == c->input->state) 
              || (NULL != c->reader && 1 == c->reader->is_done)) { // TODO: does this need to be synced?
+              block_destroy(b);
               break;
           }
           else {
@@ -361,6 +362,7 @@ consumer_run(void *arg)
               exit(1);
           }
           else {
+              block_destroy(b);
               break;
           }
       }


### PR DESCRIPTION
Hi Nils
This is the fix I mailed you about a while ago. I've only just got round to committing it - sorry about that.

When the consumer is processing blocks it takes them off the queue. If at that instant the consumer's input or output queues go into QUEUE_STATE_EOF the block is not in the queue so won't get freed by queue_destroy, so needs to be freed in the consumer. It's two one line additions (block_destroy calls) in consumer_run.

Steve
